### PR TITLE
Allow boosting loudness using lode

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -6,8 +6,8 @@ local MODNAME = minetest.get_current_modname()
 -- How tall is this bell and what note is it?
 local function traverse_bell(pos, size, dir)
     if not size then
-        local s, n = traverse_bell(pos, 0, 1) -- First go up, size 0
-        return (traverse_bell({x = pos.x, y = pos.y - 1, z = pos.z}, s, -1)), n -- Then down, adding to size
+        local s, n, t = traverse_bell(pos, 0, 1) -- First go up, size 0
+        return (traverse_bell({x = pos.x, y = pos.y - 1, z = pos.z}, s, -1)), n, t -- Then down, adding to size
     end
 
     local name = minetest.get_node(pos).name
@@ -16,23 +16,60 @@ local function traverse_bell(pos, size, dir)
     if size < 8 and note == 1 then -- Continue traversal along full bells within 8 nodes
         return traverse_bell({x = pos.x, y = pos.y + dir, z = pos.z}, size + 1, dir)
     else -- If partial bell or no bell, return current size (increment if top bell) and note (1 if no bell)
-        return size + ((note and dir > 0) and 1 or 0), note or 1
+        return size + ((note and dir > 0) and 1 or 0), note or 1, pos
     end
+end
+
+local BOOSTEXP = 1.5
+local function lodeat(pos, rx, ry, rz)
+    local node = minetest.get_node({x = pos.x + rx, y = pos.y + ry, z = pos.z + rz})
+    return minetest.get_item_group(node.name, "lode_cube") > 0
+end
+local function gainboost(pos)
+    if not lodeat(pos, 0, -1, 0) then return 1 end
+    local boost = 1
+    for y = 0, 8 do
+        local qty = (lodeat(pos, -1, y, 0) and 0.25 or 0)
+            + (lodeat(pos, 1, y, 0) and 0.25 or 0)
+            + (lodeat(pos, 0, y, -1) and 0.25 or 0)
+            + (lodeat(pos, 0, y, 1) and 0.25 or 0)
+        boost = boost + qty
+        if qty <= 0 then return BOOSTEXP ^ boost end
+    end
+    return BOOSTEXP ^ boost
 end
 
 -- Play a note at a pos
 local function play_note(pos)
     if not minetest.get_node(pos).name:match(MODNAME .. ":bell_") then return end
 
-    local size, note = traverse_bell(pos)
+    local size, note, top = traverse_bell(pos)
     local step = (12 * (9 - math.min(size, 8) - 5)) - 1 + note -- ding.ogg is A5
 
-    minetest.sound_play("ncbells_ding", {
-        pos = pos,
-        gain = BELL_GAIN,
-        max_hear_distance = BELL_HEAR,
-        pitch = (2 ^ (1 / 12)) ^ step, -- https://pages.mtu.edu/~suits/NoteFreqCalcs.html
-    }, true)
+    local bottom = {x = top.x, y = top.y - size, z = top.z}
+    local boost = gainboost(bottom)
+    local gain = BELL_GAIN * boost
+
+    local function play_core(dist, subgain)
+        return minetest.sound_play("ncbells_ding", {
+            pos = {
+                x = pos.x + (math.random() - 0.5) * dist,
+                y = pos.y + (math.random() - 0.5) * dist,
+                z = pos.z + (math.random() - 0.5) * dist,
+            },
+            gain = subgain,
+            max_hear_distance = BELL_HEAR * (boost ^ 0.5),
+            pitch = (2 ^ (1 / 12)) ^ step, -- https://pages.mtu.edu/~suits/NoteFreqCalcs.html
+        }, true)
+    end
+    -- Minetest doesn't really like playing sounds with gain > 1,
+    -- so if necessary, split it into multiple sounds.  Add a slight
+    -- offset to give it more spatial volume.
+    while gain > 1 do
+        play_core(math.sqrt(gain), 1)
+        gain = gain - 1
+    end
+    play_core(0, gain)
 end
 
 -- 12 bells, 12 notes


### PR DESCRIPTION
Building a lode "tube", capped at the bottom,
around a bell will boost the volume of the note it plays, as well as the max hear distance.