### PR TITLE
Define mapcolor

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -90,6 +90,7 @@ for s = 1, 12 do
                 nodecore.player_discover(placer, "ncbells:octave bell")
             end
         end,
+        mapcolor = {r = 139, g = 187, b = 212, a = 64},
     })
 end
 


### PR DESCRIPTION
In an upcoming release, NodeCore will be ensuring that all mods provide color data for minetestmapper (so that we can take advantage of lua for things like "inheritance" and interpolation)